### PR TITLE
feature: increase the message receive timeout

### DIFF
--- a/src/guacd/proc.h
+++ b/src/guacd/proc.h
@@ -31,7 +31,7 @@
  * The number of milliseconds to wait for messages in any phase before
  * timing out and closing the connection with an error.
  */
-#define GUACD_TIMEOUT 15000
+#define GUACD_TIMEOUT 30000
 
 /**
  * The number of microseconds to wait for messages in any phase before


### PR DESCRIPTION
Give more time for client to reconnect in case of lost connection or
switching between LAN and Wifi etc.

Signed-off-by: Gyorgy Krajcsovits <gyorgy.krajcsovits@oneidentity.com>