### PR TITLE
feat: set message receive timeout back to 30 sec

### DIFF
--- a/src/guacd/proc.h
+++ b/src/guacd/proc.h
@@ -31,7 +31,7 @@
  * The number of milliseconds to wait for messages in any phase before
  * timing out and closing the connection with an error.
  */
-#define GUACD_TIMEOUT 20000
+#define GUACD_TIMEOUT 30000
 
 /**
  * The number of microseconds to wait for messages in any phase before


### PR DESCRIPTION
Decreasing the timeout has minimal effect on memory usage
hence changing it back to original value of 30 sec because
re-connection is more reliable in this way

Signed-off-by: Gergely Orosz <gergely.orosz@oneidentity.com>